### PR TITLE
feature/add-option-to-save-output-to-file

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,10 @@
 # Change Log
 
-## 0.1.0
+## 1.1.0
+
+- Updated the sites_list, subsites_list, and doc_lib_list actions to optionally save outputs to files.
+
+## 1.0.0
 
 - First release
 - Added the following actions:

--- a/actions/doc_lib_list.py
+++ b/actions/doc_lib_list.py
@@ -10,14 +10,20 @@ class DocLibList(SharepointBaseAction):
         """
         super(DocLibList, self).__init__(config)
 
-    def run(self, domain, password, site_url, username):
+    def run(self, domain, output_file, output_file_append, output_type,
+            password, site_url, username):
         """
         Return a list of document libraries on the given site or subsite
 
         Args:
-        - base_url: URL of the base Sharepoint site
         - domain: Domain for the given username
+        - output_file: (Optional) file to save sites output to
+        - output_file_append: Boolean, whether to append the sites list to the
+            given file or overwrite it
+        - output_type: "console" or "file" specifies whether to send output to
+            console or save it in a specified file
         - password: Password to login to sharepoint
+        - site_url: URL of the base Sharepoint site
         - username: Username to login to sharepoint
 
         Returns:
@@ -25,6 +31,10 @@ class DocLibList(SharepointBaseAction):
         """
         user_auth = self.create_auth_cred(domain, username, password)
 
-        result = self.get_doc_libs(site_url, user_auth)
+        doc_libs = self.get_doc_libs(site_url, user_auth)
 
-        return result
+        if output_type == 'file':
+            return self.save_sites_list_to_file(doc_libs, output_file,
+                                                output_file_append)
+
+        return doc_libs

--- a/actions/doc_lib_list.yaml
+++ b/actions/doc_lib_list.yaml
@@ -9,6 +9,23 @@ parameters:
     type: string
     description: "Domain for the given username"
     required: true
+  output_file:
+    type: string
+    description: "Path to JSON file that will store a list of sites"
+    required: false
+  output_file_append:
+    type: boolean
+    description: "Whether to append the result to the given file or overwrite it"
+    default: true
+    required: true
+  output_type:
+    type: string
+    description: "Specifies whether to send output to console or save it in a specified file"
+    enum:
+      - console
+      - file
+    required: true
+    default: console
   password:
     type: string
     description: "Password to login to sharepoint"

--- a/actions/lib/base_action.py
+++ b/actions/lib/base_action.py
@@ -1,4 +1,5 @@
 import requests
+import json
 from requests_ntlm import HttpNtlmAuth
 from st2common.runners.base_action import Action
 
@@ -51,6 +52,30 @@ class SharepointBaseAction(Action):
         """
         login_user = domain + "\\" + username
         return HttpNtlmAuth(login_user, password)
+
+    def save_sites_list_to_file(self, site_objs, file_path, file_append):
+        """Write the given list of sharepoint sites to the specified file
+        :param site_objs: List of Sharepoint site objects
+        :param file_path: Path to the file that will store the list of sites
+        :param file_append: Boolean, if true append sites to end of file otherwise overwrite it
+        """
+        if not file_path:
+            raise 'output_file path must be specified to save output to file.'
+
+        # If appending sites to the file then read in the file first before overwriting it
+        if file_append:
+            file = open(file_path, 'r')
+            sites_list = json.loads(file.read())
+            file.close()
+            sites_list.extend(site_objs)
+        else:
+            sites_list = site_objs
+
+        with open(file_path, 'w') as outfile:
+            json.dump(sites_list, outfile)
+            outfile.close()
+
+        return 'Output saved to: ' + file_path
 
     # Need this method here because of the following error with unit tests
     # TypeError: Can't instantiate class with abstract methods run

--- a/actions/sites_list.py
+++ b/actions/sites_list.py
@@ -48,22 +48,34 @@ class SitesList(SharepointBaseAction):
 
         return site_urls
 
-    def run(self, base_url, domain, password, username):
+    def run(self, base_url, domain, output_file, output_file_append,
+            output_type, password, username):
         """
         Return a list of subsites on the given base site
 
         Args:
         - base_url: URL of the base Sharepoint site
         - domain: Domain for the given username
+        - output_file: (Optional) file to save sites output to
+        - output_file_append: Boolean, whether to append the sites list to the
+            given file or overwrite it
+        - output_type: "console" or "file" specifies whether to send output to
+            console or save it in a specified file
         - password: Password to login to sharepoint
         - username: Username to login to sharepoint
 
         Returns:
-        - List: List of Sharepoint sites and subsites
+        - List: List of Sharepoint sites and subsites if output_type is "console"
+        - String: Path to the output file if output_type is "file"
         """
         user_auth = self.create_auth_cred(domain, username, password)
 
         sites_list = self.get_sites_list(base_url, user_auth)
         site_objs = self.get_site_objects(base_url, user_auth, sites_list)
+
+        # If the output type is file then return a string with the path to the file
+        if output_type == 'file':
+            return self.save_sites_list_to_file(site_objs, output_file,
+                                                output_file_append)
 
         return site_objs

--- a/actions/sites_list.yaml
+++ b/actions/sites_list.yaml
@@ -13,6 +13,23 @@ parameters:
     type: string
     description: "Domain for the given username"
     required: true
+  output_file:
+    type: string
+    description: "Path to JSON file that will store a list of sites"
+    required: false
+  output_file_append:
+    type: boolean
+    description: "Whether to append the result to the given file or overwrite it"
+    default: true
+    required: true
+  output_type:
+    type: string
+    description: "Specifies whether to send output to console or save it in a specified file"
+    enum:
+      - console
+      - file
+    required: true
+    default: console
   password:
     type: string
     description: "Password to login to sharepoint"

--- a/actions/subsites_list.py
+++ b/actions/subsites_list.py
@@ -38,7 +38,8 @@ class SubsitesList(SharepointBaseAction):
 
         return site_list
 
-    def run(self, base_url, endpoint, domain, password, username):
+    def run(self, base_url, domain, endpoint, output_file, output_file_append,
+            output_type, password, username):
         """
         Return a list of subsites on the given base site
 
@@ -46,14 +47,25 @@ class SubsitesList(SharepointBaseAction):
         - base_url: URL of the base Sharepoint site
         - domain: Domain for the given username
         - endpoint: Endpoint to get the list of subsites for
+        - output_file: (Optional) file to save sites output to
+        - output_file_append: Boolean, whether to append the sites list to the
+            given file or overwrite it
+        - output_type: "console" or "file" specifies whether to send output to
+            console or save it in a specified file
         - password: Password to login to sharepoint
         - username: Username to login to sharepoint
 
         Returns:
-        - List: List of Sharepoint sites and subsites
+        - List: List of Sharepoint sites and subsites if output_type is "console"
+        - String: Path to the output file if output_type is "file"
         """
         user_auth = self.create_auth_cred(domain, username, password)
 
-        result = self.get_sites_list(base_url, user_auth, endpoint)
+        site_objs = self.get_sites_list(base_url, user_auth, endpoint)
 
-        return result
+        # If the output type is file then return a string with the path to the file
+        if output_type == 'file':
+            return self.save_sites_list_to_file(site_objs, output_file,
+                                                output_file_append)
+
+        return site_objs

--- a/actions/subsites_list.yaml
+++ b/actions/subsites_list.yaml
@@ -17,6 +17,23 @@ parameters:
     type: string
     description: "Endpoint to get list of subsites for"
     default: ''
+  output_file:
+    type: string
+    description: "Path to JSON file that will store a list of sites"
+    required: false
+  output_file_append:
+    type: boolean
+    description: "Whether to append the result to the given file or overwrite it"
+    default: true
+    required: true
+  output_type:
+    type: string
+    description: "Specifies whether to send output to console or save it in a specified file"
+    enum:
+      - console
+      - file
+    required: true
+    default: console
   password:
     type: string
     description: "Password to login to sharepoint"

--- a/pack.yaml
+++ b/pack.yaml
@@ -5,6 +5,6 @@ runner_type: "python-script"
 description: SharePoint integrations
 keywords:
     - sharepoint
-version: 1.0.0
+version: 1.1.0
 author: Encore Technologies
 email: code@encore.tech

--- a/tests/test_action_doc_lib_list.py
+++ b/tests/test_action_doc_lib_list.py
@@ -33,6 +33,9 @@ class SharepointSitesListTest(SharePointBaseActionTestCase):
 
         test_site_url = 'https://test.com'
         test_domain = 'dom'
+        test_output_file = None
+        test_output_file_append = False
+        test_output_type = 'console'
         test_pass = 'pass'
         test_user = 'user'
         test_auth = 'auth'
@@ -43,8 +46,39 @@ class SharepointSitesListTest(SharePointBaseActionTestCase):
 
         mock_get_doc_libs.return_value = expected_result
 
-        result = action.run(test_domain, test_pass, test_site_url, test_user)
+        result = action.run(test_domain, test_output_file, test_output_file_append,
+                            test_output_type, test_pass, test_site_url, test_user)
 
         self.assertEqual(result, expected_result)
         mock_auth.assert_called_with(test_domain, test_user, test_pass)
         mock_get_doc_libs.assert_called_with(test_site_url, test_auth)
+
+    @mock.patch('lib.base_action.SharepointBaseAction.get_doc_libs')
+    @mock.patch('lib.base_action.SharepointBaseAction.create_auth_cred')
+    @mock.patch('lib.base_action.SharepointBaseAction.save_sites_list_to_file')
+    def test_run_file(self, mock_save, mock_auth, mock_get_doc_libs):
+        action = self.get_action_instance({})
+
+        test_site_url = 'https://test.com/'
+        test_domain = 'dom'
+        test_output_file = '/path/to/sites_file.json'
+        test_output_file_append = False
+        test_output_type = 'file'
+        test_pass = 'pass'
+        test_user = 'user'
+        test_auth = 'auth'
+        test_doc_libs = ['doc1', 'doc2']
+
+        expected_result = 'result'
+
+        mock_auth.return_value = test_auth
+        mock_get_doc_libs.return_value = test_doc_libs
+        mock_save.return_value = expected_result
+
+        result = action.run(test_domain, test_output_file, test_output_file_append,
+                            test_output_type, test_pass, test_site_url, test_user)
+
+        self.assertEqual(result, expected_result)
+        mock_auth.assert_called_with(test_domain, test_user, test_pass)
+        mock_get_doc_libs.assert_called_with(test_site_url, test_auth)
+        mock_save.assert_called_with(test_doc_libs, test_output_file, test_output_file_append)

--- a/tests/test_action_lib_base_action.py
+++ b/tests/test_action_lib_base_action.py
@@ -102,3 +102,45 @@ class SharePointBaseActionTestCase(BaseActionTestCase):
 
         self.assertEqual(result, test_auth)
         mock_auth.assert_called_with(test_domain + '\\' + test_user, test_pass)
+
+    @mock.patch("lib.base_action.json")
+    @mock.patch("lib.base_action.open")
+    def test_save_sites_list_to_file_append(self, mock_open, mock_json):
+        action = self.get_action_instance({})
+
+        test_site_objs = ['site1', 'site2']
+        test_file_path = '/path/to/sites_file.json'
+        test_file_append = True
+        expected_result = 'Output saved to: ' + test_file_path
+
+        m = mock.mock_open(read_data='test data')
+        mock_open.return_value = m.return_value
+        mock_json.loads.return_value = ['site3', 'site4']
+
+        result = action.save_sites_list_to_file(test_site_objs, test_file_path, test_file_append)
+
+        self.assertEqual(result, expected_result)
+        mock_json.loads.assert_called_with('test data')
+        mock_json.dump.assert_called_with(['site3', 'site4', 'site1', 'site2'], m.return_value)
+        mock_open.assert_has_calls(
+            [mock.call(test_file_path, 'r'),
+             mock.call(test_file_path, 'w')])
+
+    @mock.patch("lib.base_action.json")
+    @mock.patch("lib.base_action.open")
+    def test_save_sites_list_to_file_overwrite(self, mock_open, mock_json):
+        action = self.get_action_instance({})
+
+        test_site_objs = ['site1', 'site2']
+        test_file_path = '/path/to/sites_file.json'
+        test_file_append = False
+        expected_result = 'Output saved to: ' + test_file_path
+
+        m = mock.mock_open(read_data='test data')
+        mock_open.return_value = m.return_value
+
+        result = action.save_sites_list_to_file(test_site_objs, test_file_path, test_file_append)
+
+        self.assertEqual(result, expected_result)
+        mock_json.dump.assert_called_with(['site1', 'site2'], m.return_value)
+        mock_open.assert_called_with(test_file_path, 'w')

--- a/tests/test_action_sites_list.py
+++ b/tests/test_action_sites_list.py
@@ -143,6 +143,9 @@ class SharepointSitesListTest(SharePointBaseActionTestCase):
 
         test_base_url = 'https://test.com/'
         test_domain = 'dom'
+        test_output_file = None
+        test_output_file_append = False
+        test_output_type = 'console'
         test_pass = 'pass'
         test_user = 'user'
         test_auth = 'auth'
@@ -155,9 +158,45 @@ class SharepointSitesListTest(SharePointBaseActionTestCase):
         mock_get_site_objects.return_value = expected_result
         mock_get_sites_list.return_value = test_site_list
 
-        result = action.run(test_base_url, test_domain, test_pass, test_user)
+        result = action.run(test_base_url, test_domain, test_output_file, test_output_file_append,
+                            test_output_type, test_pass, test_user)
 
         self.assertEqual(result, expected_result)
         mock_auth.assert_called_with(test_domain, test_user, test_pass)
         mock_get_sites_list.assert_called_with(test_base_url, test_auth)
         mock_get_site_objects.assert_called_with(test_base_url, test_auth, test_site_list)
+
+    @mock.patch('sites_list.SitesList.get_sites_list')
+    @mock.patch('sites_list.SitesList.get_site_objects')
+    @mock.patch('lib.base_action.SharepointBaseAction.create_auth_cred')
+    @mock.patch('lib.base_action.SharepointBaseAction.save_sites_list_to_file')
+    def test_run_file(self, mock_save, mock_auth, mock_get_site_objects, mock_get_sites_list):
+        action = self.get_action_instance({})
+
+        test_base_url = 'https://test.com/'
+        test_domain = 'dom'
+        test_output_file = '/path/to/sites_file.json'
+        test_output_file_append = False
+        test_output_type = 'file'
+        test_pass = 'pass'
+        test_user = 'user'
+        test_auth = 'auth'
+        test_site_list = ['site1', 'site2']
+        test_site_object = {'site': 'object'}
+
+        expected_result = 'result'
+
+        mock_auth.return_value = test_auth
+
+        mock_get_site_objects.return_value = test_site_object
+        mock_get_sites_list.return_value = test_site_list
+        mock_save.return_value = expected_result
+
+        result = action.run(test_base_url, test_domain, test_output_file, test_output_file_append,
+                            test_output_type, test_pass, test_user)
+
+        self.assertEqual(result, expected_result)
+        mock_auth.assert_called_with(test_domain, test_user, test_pass)
+        mock_get_sites_list.assert_called_with(test_base_url, test_auth)
+        mock_get_site_objects.assert_called_with(test_base_url, test_auth, test_site_list)
+        mock_save.assert_called_with(test_site_object, test_output_file, test_output_file_append)

--- a/tests/test_action_subsites_list.py
+++ b/tests/test_action_subsites_list.py
@@ -147,6 +147,9 @@ class SharepointSubsitesListTest(SharePointBaseActionTestCase):
 
         test_base_url = 'https://test.com/'
         test_domain = 'dom'
+        test_output_file = None
+        test_output_file_append = False
+        test_output_type = 'console'
         test_pass = 'pass'
         test_user = 'user'
         test_auth = 'auth'
@@ -157,9 +160,40 @@ class SharepointSubsitesListTest(SharePointBaseActionTestCase):
         mock_auth.return_value = test_auth
         mock_get_sites_list.return_value = expected_result
 
-        result = action.run(test_base_url, test_endpoint, test_domain,
-                            test_pass, test_user)
+        result = action.run(test_base_url, test_domain, test_endpoint, test_output_file,
+                            test_output_file_append, test_output_type, test_pass, test_user)
 
         self.assertEqual(result, expected_result)
         mock_auth.assert_called_with(test_domain, test_user, test_pass)
         mock_get_sites_list.assert_called_with(test_base_url, test_auth, test_endpoint)
+
+    @mock.patch('subsites_list.SubsitesList.get_sites_list')
+    @mock.patch('lib.base_action.SharepointBaseAction.create_auth_cred')
+    @mock.patch('lib.base_action.SharepointBaseAction.save_sites_list_to_file')
+    def test_run_file(self, mock_save, mock_auth, mock_get_sites_list):
+        action = self.get_action_instance({})
+
+        test_base_url = 'https://test.com/'
+        test_domain = 'dom'
+        test_output_file = '/path/to/sites_file.json'
+        test_output_file_append = False
+        test_output_type = 'file'
+        test_pass = 'pass'
+        test_user = 'user'
+        test_auth = 'auth'
+        test_endpoint = 'endp1'
+        test_sites = ['site1', 'site2']
+
+        expected_result = 'result'
+
+        mock_auth.return_value = test_auth
+        mock_get_sites_list.return_value = test_sites
+        mock_save.return_value = expected_result
+
+        result = action.run(test_base_url, test_domain, test_endpoint, test_output_file,
+                            test_output_file_append, test_output_type, test_pass, test_user)
+
+        self.assertEqual(result, expected_result)
+        mock_auth.assert_called_with(test_domain, test_user, test_pass)
+        mock_get_sites_list.assert_called_with(test_base_url, test_auth, test_endpoint)
+        mock_save.assert_called_with(test_sites, test_output_file, test_output_file_append)


### PR DESCRIPTION
Added option to save output to a file because the site objects getting passed between actions were sometimes too large and causing read/write timeouts in mongodb